### PR TITLE
Handle angular non-EventEmitter outputs

### DIFF
--- a/tests/components/ct-angular/src/components/output.component.ts
+++ b/tests/components/ct-angular/src/components/output.component.ts
@@ -1,0 +1,17 @@
+import { DOCUMENT } from "@angular/common";
+import { Component, Output, inject } from "@angular/core";
+import { Subject, finalize } from "rxjs";
+
+@Component({
+  standalone: true,
+  template: `OutputComponent`,
+})
+export class OutputComponent {
+  @Output() answerChange = new Subject().pipe(
+    /* Detect when observable is unsubscribed from, 
+     * and set a global variable `hasUnsubscribed` to true. */
+    finalize(() => ((this._window as any).hasUnsubscribed = true))
+  );
+
+  private _window = inject(DOCUMENT).defaultView;
+}

--- a/tests/components/ct-angular/tests/events.spec.ts
+++ b/tests/components/ct-angular/tests/events.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/experimental-ct-angular';
 import { ButtonComponent } from '@/components/button.component';
+import { OutputComponent } from '@/components/output.component';
 
 test('emit an submit event when the button is clicked', async ({ mount }) => {
   const messages: string[] = [];
@@ -13,4 +14,23 @@ test('emit an submit event when the button is clicked', async ({ mount }) => {
   });
   await component.click();
   expect(messages).toEqual(['hello']);
+});
+
+test('unsubscribe from events when the component is unmounted', async ({
+  mount,
+  page,
+}) => {
+  test.skip(true, '🚧 work in progress');
+  const component = await mount(OutputComponent, {
+    on: {
+      answerChange: () => {},
+    },
+  });
+
+  await component.unmount();
+
+  /* Check that the output observable had been unsubscribed from
+   * as it sets a global variable `hasUnusbscribed` to true
+   * when it detects unsubscription. Cf. OutputComponent. */
+  expect(await page.evaluate(() => (window as any).hasUnsubscribed)).toBe(true);
 });

--- a/tests/components/ct-angular/tests/events.spec.ts
+++ b/tests/components/ct-angular/tests/events.spec.ts
@@ -16,6 +16,36 @@ test('emit an submit event when the button is clicked', async ({ mount }) => {
   expect(messages).toEqual(['hello']);
 });
 
+test('replace existing listener when new listener is set', async ({
+  mount,
+}) => {
+  test.skip(true, '🚧 work in progress');
+
+  let count = 0;
+
+  const component = await mount(ButtonComponent, {
+    props: {
+      title: 'Submit',
+    },
+    on: {
+      submit() {
+        count++;
+      },
+    },
+  });
+
+  component.update({
+    on: {
+      submit() {
+        count++;
+      },
+    },
+  });
+
+  await component.click();
+  expect(count).toBe(1);
+});
+
 test('unsubscribe from events when the component is unmounted', async ({
   mount,
   page,
@@ -23,7 +53,7 @@ test('unsubscribe from events when the component is unmounted', async ({
   test.skip(true, '🚧 work in progress');
   const component = await mount(OutputComponent, {
     on: {
-      answerChange: () => {},
+      answerChange() {},
     },
   });
 

--- a/tests/components/ct-angular/tests/events.spec.ts
+++ b/tests/components/ct-angular/tests/events.spec.ts
@@ -19,8 +19,6 @@ test('emit an submit event when the button is clicked', async ({ mount }) => {
 test('replace existing listener when new listener is set', async ({
   mount,
 }) => {
-  test.skip(true, '🚧 work in progress');
-
   let count = 0;
 
   const component = await mount(ButtonComponent, {
@@ -50,7 +48,6 @@ test('unsubscribe from events when the component is unmounted', async ({
   mount,
   page,
 }) => {
-  test.skip(true, '🚧 work in progress');
   const component = await mount(OutputComponent, {
     on: {
       answerChange() {},


### PR DESCRIPTION
- test(ct): test non-event-emitter outputs
- test(ct): test output listener replacement
- feat(ct): support non-event-emitter outputs
