### PR TITLE
feat(ct): add mount support for template strings

### DIFF
--- a/packages/playwright-ct-angular/index.d.ts
+++ b/packages/playwright-ct-angular/index.d.ts
@@ -17,7 +17,7 @@
 import type { Locator } from 'playwright/test';
 import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
 import type { TestType } from '@playwright/experimental-ct-core';
-import type { Type } from '@angular/core';
+import type { EnvironmentProviders, Provider, Type } from '@angular/core';
 
 export type ComponentEvents = Record<string, Function>;
 
@@ -25,6 +25,10 @@ export interface MountOptions<HooksConfig extends JsonObject, Component> {
   props?: Partial<Component> | Record<string, unknown>, // TODO: filter props and handle signals
   on?: ComponentEvents;
   hooksConfig?: HooksConfig;
+  imports?: (Type<any> | ReadonlyArray<any>)[]
+  environmentProviders?: (EnvironmentProviders | Provider)[]
+  providers?: Provider[]
+  viewProviders?: Provider[]
 }
 
 export interface MountResult<Component> extends Locator {
@@ -37,7 +41,7 @@ export interface MountResult<Component> extends Locator {
 
 export const test: TestType<{
   mount<HooksConfig extends JsonObject, Component = unknown>(
-    component: Type<Component>,
+    component: Type<Component> | string,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;
 }>;

--- a/tests/components/ct-angular/playwright.config.mts
+++ b/tests/components/ct-angular/playwright.config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
     ctViteConfig: {
       plugins: [angular({
         tsconfig: resolve('./tsconfig.spec.json'),
+        jit: true // must use jit otherwise TestBed.overrideComponent fails
       }) as any], // TODO: remove any and resolve various installed conflicting Vite versions
       resolve: {
         alias: {

--- a/tests/components/ct-angular/src/components/button.component.ts
+++ b/tests/components/ct-angular/src/components/button.component.ts
@@ -4,10 +4,10 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   standalone: true,
   selector: 'app-button',
   template: `
-  <button (click)="submit.emit('hello')">{{title}}</button>
+  <button (click)="click.emit('hello')">{{title}}</button>
   `
 })
 export class ButtonComponent {
   @Input({required: true}) title!: string;
-  @Output() submit = new EventEmitter();
+  @Output('submit') click = new EventEmitter();
 }

--- a/tests/components/ct-angular/src/components/counter.component.ts
+++ b/tests/components/ct-angular/src/components/counter.component.ts
@@ -10,6 +10,12 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
       <ng-content></ng-content>
     </div>
   `,
+  styles: [`
+    :host {
+      display: block;
+      padding: 20px;
+    }
+  `]
 })
 export class CounterComponent {
   remountCount = Number(localStorage.getItem('remountCount'));

--- a/tests/components/ct-angular/src/components/named-slots.component.ts
+++ b/tests/components/ct-angular/src/components/named-slots.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   standalone: true,
+  selector: 'app-named-slots',
   template: `
     <div>
       <header>

--- a/tests/components/ct-angular/src/components/providers.component.ts
+++ b/tests/components/ct-angular/src/components/providers.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject, Injectable, NgModule } from '@angular/core';
+
+@Injectable()
+export class Store {
+  state = {
+    text: `Store`
+  }
+}
+
+@NgModule({
+  providers: [Store]
+})
+export class StoreModule {}
+
+@Component({
+  standalone: true,
+  selector: 'app-imports',
+  template: `
+    {{ provider?.state.text }}: from provider
+    {{ environmentProvider?.state.text }}: from environmentProvider
+  `
+})
+export class ProvidersComponent {
+  provider = inject(Store, { self: true, optional: true })
+  environmentProvider = inject(Store, { skipSelf: true, optional: true })
+}

--- a/tests/components/ct-angular/tests/events.spec.ts
+++ b/tests/components/ct-angular/tests/events.spec.ts
@@ -12,7 +12,7 @@ test('emit an submit event when the button is clicked', async ({ mount }) => {
       submit: (data: string) => messages.push(data),
     },
   });
-  await component.click();
+  await component.locator('css=button').click();
   expect(messages).toEqual(['hello']);
 });
 
@@ -38,7 +38,7 @@ test('replace existing listener when new listener is set', async ({
     },
   });
 
-  await component.click();
+  await component.locator('css=button').click();
   expect(called).toBe(true);
 });
 

--- a/tests/components/ct-angular/tests/injection.spec.ts
+++ b/tests/components/ct-angular/tests/injection.spec.ts
@@ -1,4 +1,4 @@
-import { InjectComponent, TOKEN } from '@/components/inject.component';
+import { InjectComponent } from '@/components/inject.component';
 import { expect, test } from '@playwright/experimental-ct-angular';
 import type { HooksConfig } from 'playwright';
 

--- a/tests/components/ct-angular/tests/providers.spec.ts
+++ b/tests/components/ct-angular/tests/providers.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/experimental-ct-angular';
+import type { HooksConfig } from '../playwright';
+import { ProvidersComponent, Store, StoreModule } from '@/components/providers.component';
+
+test('should add imports', async ({ mount }) => {
+  const component = await mount<HooksConfig>(ProvidersComponent, {
+    imports: [StoreModule],
+  });
+  await expect(component).toContainText('Store: from environmentProvider')
+  await expect(component).not.toContainText('Store: from provider')
+})
+
+test('should add environment providers', async ({ mount }) => {
+  const component = await mount<HooksConfig>(ProvidersComponent, {
+    environmentProviders: [Store],
+  });
+
+  await expect(component).toContainText('Store: from environmentProvider')
+  await expect(component).not.toContainText('Store: from provider')
+})
+
+test('should add component providers', async ({ mount }) => {
+  const component = await mount<HooksConfig>(ProvidersComponent, {
+    providers: [Store],
+  });
+
+  await expect(component).not.toContainText('Store: from environmentProvider')
+  await expect(component).toContainText('Store: from provider')
+})
+
+test('should add component view providers', async ({ mount }) => {
+  const component = await mount<HooksConfig>(ProvidersComponent, {
+    viewProviders: [Store],
+  });
+
+  await expect(component).not.toContainText('Store: from environmentProvider')
+  await expect(component).toContainText('Store: from provider')
+})

--- a/tests/components/ct-angular/tests/slots.spec.ts
+++ b/tests/components/ct-angular/tests/slots.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/experimental-ct-angular';
+import { NamedSlotsComponent } from '@/components/named-slots.component';
+
+test('should render a string', async ({ mount }) => {
+  const component = await mount(`
+    <app-named-slots>
+      <div header>{{header}}</div>
+      <div main>{{main}}</div>
+      <div footer>{{footer}}</div>
+    </app-named-slots>
+  `, {
+    imports: [NamedSlotsComponent],
+    props: {
+      header: "Header",
+      main: "Main",
+      footer: "Footer"
+    }
+  });
+
+  await expect(component.getByRole('banner')).toHaveText('Header')
+  await expect(component.getByRole('main')).toHaveText('Main')
+  await expect(component.getByRole('contentinfo')).toHaveText('Footer')
+})

--- a/tests/components/ct-angular/tests/template.spec.ts
+++ b/tests/components/ct-angular/tests/template.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/experimental-ct-angular';
+import type { HooksConfig } from '../playwright';
+import { ButtonComponent } from '@/components/button.component';
+
+test('should render a string', async ({ mount }) => {
+  const messages = [] as any[]
+  const component = await mount<HooksConfig>(`<app-button data-testid="test" [title]="title" (click)="message.emit('Clicked!')" />`, {
+    imports: [ButtonComponent],
+    props: {
+      title: "Hello!"
+    },
+    on: {
+      message: (value: any) => messages.push(value)
+    }
+  });
+
+  await expect(component).toHaveText('Hello!')
+
+  await component.update({
+    props: {
+      title: 'Goodbye!'
+    }
+  })
+
+  await expect(component).toHaveText('Goodbye!')
+
+  await component.getByTestId('test').click()
+
+  expect(messages).toEqual(['Clicked!'])
+})

--- a/tests/components/ct-angular/tests/update.spec.ts
+++ b/tests/components/ct-angular/tests/update.spec.ts
@@ -25,7 +25,9 @@ test('update event listeners without remounting', async ({ mount }) => {
       submit: (data: string) => messages.push(data),
     },
   });
-  await component.click();
+  await component.locator('css=div').first().click({
+    position: { x: 0, y: 0 }
+  });
   expect(messages).toEqual(['hello']);
 
   await expect(component.getByTestId('remount-count')).toContainText('1');


### PR DESCRIPTION
This PR adds support for mounting Angular components via a template string. This enables a number of additional test cases:

1. Testing content projection via `ng-content`
2. Testing directives
3. Testing pipes
4. Testing component boundaries

Mount has been extended with the following additional options:

`imports` - If a string template is passed to mount, imports are passed to `WrapperComponent` imports. If a component is passed to mount, imports are passed to `TestBed.configureModule`. It is done this way to prevent users from adding new declarables to the component's scope.

---

The intention behind adding the following options is to enable testing all of the component's boundaries.  They are not needed for mounting template strings.

`environmentProviders` - Passed to `TestBed.configureModule` for top level providers that should exist outside of the component injector, such as `provideStore` from ngrx.

`providers`/`viewProviders` - Passed to `TestBed.overrideComponent` intended for stubbing component level providers.

---

This PR also contains a number of fixes for the mount function so that it reuses the root element given by Playwright and properly maps aliased component outputs.